### PR TITLE
Add missing 'use strict' directives

### DIFF
--- a/lib/check/CheckBodyStream.js
+++ b/lib/check/CheckBodyStream.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Writable = require('stream').Writable;
 const diff = require('./diff');
 

--- a/lib/check/checker.js
+++ b/lib/check/checker.js
@@ -1,6 +1,7 @@
+'use strict';
+
 const isInclude = require('./isInclude');
 const url = require("url");
-
 
 class Checker {
   static request(request, req) {

--- a/lib/check/completion.js
+++ b/lib/check/completion.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const pathToRegexp = require('path-to-regexp');
 const path = require('path');
 const requireUncached = require('../require_hook/requireUncached');

--- a/lib/check/isAbsolutePath.js
+++ b/lib/check/isAbsolutePath.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 
 module.exports = (path) => {

--- a/lib/check/isContentJSON.js
+++ b/lib/check/isContentJSON.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports =  (obj) => {
   const isContentJSON = obj.headers && obj.headers['Content-Type'] === 'application/json';
   return isContentJSON || typeof obj.body === 'object'

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const json5Hook = require('./require_hook/json5');
 const yamlHook = require('./require_hook/yaml');
 

--- a/lib/require_hook/hook.js
+++ b/lib/require_hook/hook.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const compile = require('./compile');
 

--- a/lib/require_hook/json5.js
+++ b/lib/require_hook/json5.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EXTENSIONS = ['.json', '.json5'];
 const JSON5 = require('json5');
 const hook = require('./hook');

--- a/lib/require_hook/yaml.js
+++ b/lib/require_hook/yaml.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EXTENSIONS = ['.yaml', '.yml'];
 const YAML = require('yamljs');
 const hook = require('./hook');

--- a/test/helper/server.js
+++ b/test/helper/server.js
@@ -1,4 +1,5 @@
-'use strinct';
+'use strict';
+
 const express = require('express');
 const bodyParser = require('body-parser');
 const agreed = require('../../index');

--- a/test/lib/check/diff.js
+++ b/test/lib/check/diff.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('eater/runner').test;
 const diff = require(`${process.cwd()}/lib/check/diff`);
 const assert = require('power-assert');

--- a/test/lib/client.js
+++ b/test/lib/client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const agreedServer = require('../helper/server.js');
 const Client = require(`${process.cwd()}/lib/client.js`);
 const test = require('eater/runner').test;

--- a/test/lib/middleware.js
+++ b/test/lib/middleware.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Server = require(`${process.cwd()}/lib/server.js`);
 
 const AssertStream = require('assert-stream');

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const agreedServer = require('../helper/server.js');
 const test = require('eater/runner').test;
 const http = require('http');

--- a/test/lib/template/bind.js
+++ b/test/lib/template/bind.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('eater/runner').test;
 const bind = require(`${process.cwd()}/lib/template/bind`);
 const assert = require('power-assert');

--- a/test/lib/template/format.js
+++ b/test/lib/template/format.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('eater/runner').test;
 const format = require(`${process.cwd()}/lib/template/format`);
 const assert = require('power-assert');


### PR DESCRIPTION
node v4 環境だと、use strict が無いというエラーで一部テストケースが通ら無いようだったので、その修正です。

I added missing 'use strict' directives to make tests pass on node v4 environment.