### PR TITLE
feat(template): Add brackets format support, {:list[:index]}

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ module.exports = [
       method: 'GET',
       query: {
         q: '{:someQueryStrings}',
+        index: '{:index}',
       },
       values: {
         id: 'yosuke',
-        someQueryStrings: 'foo'
+        someQueryStrings: 'bye',
+        index: 2,
       },
     },
     response: {
@@ -47,8 +49,11 @@ module.exports = [
         'x-csrf-token': 'csrf-token', 
       },
       body: {
+        // hello yosuke bye
         message: '{:greeting} {:id} {:someQueryStrings}',
-        images: '{:images}',
+        // http://example.com/baz.jpg 
+        image: '{:images[:index]}',
+        // { name: 'green' }
         themes: '{:themes}',
       },
       values: {
@@ -56,6 +61,7 @@ module.exports = [
         images: [
           'http://example.com/foo.jpg',
           'http://example.com/bar.jpg',
+          'http://example.com/baz.jpg',
         ],
         themes: {
           name: 'green',

--- a/lib/template/format.js
+++ b/lib/template/format.js
@@ -20,13 +20,29 @@ function format(template, args) {
   if (!args) return result;
   if (Object.keys(args).length === 0) return result;
 
-  const matches = template.match(/\{:([\w|\.]+)\}/g);
+  // matches {:foo} {:foo.bar} {:foo[:aaa]}
+  const matches = template.match(/\{:([\w|\.|:|\[|\]]+)\}/g);
   
   if (!matches) return result;
 
   matches.forEach((match) => {
-    const rawKey = match.replace(/\{:([\w|\.]+)\}/, '$1');
-    const value = rawKey.split('.').reduce((o, i) => o[i], args);
+    var rawKey = match.replace(/\{:([\w|\.|:|\[|\]]+)\}/, '$1');
+
+    // brackets notation like '{:array[:index]}'
+    if (rawKey.indexOf('[:') >= 0) {
+      const matches = rawKey.match(/\[:([\w]+)\]/g);
+
+      matches && matches.forEach((match) => {
+        const key = match.replace(/\[:([\w]+)\]/, '$1');
+        const value = '.' + key.split('.').reduce((o, i) => o && o[i], args);
+
+        if (value != null) {
+          rawKey = rawKey.replace(match, value);
+        }
+      });
+    }
+
+    const value = rawKey.split('.').reduce((o, i) => o && o[i], args);
     if (value != null) {
       if (match === template) {
         result = value;

--- a/test/agrees/agrees.js
+++ b/test/agrees/agrees.js
@@ -164,4 +164,25 @@ module.exports = [
       }
     },
   },
+  {
+    request: {
+      path: '/list/:index',
+      method: 'GET',
+      values: {
+        index: 1
+      }
+    },
+    response: {
+      body: {
+        result : '{:list[:index]}'
+      },
+      values: {
+        list: [
+          'hello',
+          'hi',
+          'dunke',
+        ]
+      }
+    },
+  },
 ]

--- a/test/lib/template/format.js
+++ b/test/lib/template/format.js
@@ -129,3 +129,75 @@ test('format: number format', () => {
   });
 });
 
+test('format: brackets notation :ghi[:id]', () => {
+  const obj = {
+    a: {
+      abc: 1
+    },
+    c: '{:ghi[:id]}',
+  };
+  const result = format(obj, {
+    id: 'fooo',
+    aa: 'barrr',
+    ghi: {
+      fooo: '123',
+      baaa: '234'
+    }
+  });
+  console.log(result);
+  assert.deepStrictEqual(result, {
+    a: {
+      abc: 1
+    },
+    c: '123',
+  });
+});
+
+test('format: brackets notation :ghi[:id][:aa]', () => {
+  const obj = {
+    a: {
+      abc: 1
+    },
+    c: '{:ghi[:id][:aa]}',
+  };
+  const result = format(obj, {
+    id: 'fooo',
+    aa: 'barrr',
+    ghi: {
+      fooo: {
+        barrr: '123'
+      },
+      baaa: '234'
+    }
+  });
+  console.log(result);
+  assert.deepStrictEqual(result, {
+    a: {
+      abc: 1
+    },
+    c: '123',
+  });
+});
+
+test('format: brackets notation to use array', () => {
+  const obj = {
+    a: {
+      abc: 1
+    },
+    c: '{:ghi[:id]}',
+  };
+  const result = format(obj, {
+    id: 1,
+    aa: 'barrr',
+    ghi: [
+      1, 2, 3
+    ]
+  });
+  assert.deepStrictEqual(result, {
+    a: {
+      abc: 1
+    },
+    c: 2,
+  });
+});
+


### PR DESCRIPTION
Support brackets format. I think this format will be used as follows.

```javascript
module.exports = [
  {
    request: {
      path: '/users/:id',
      method: 'GET',
      values: {
        id: 2,
      },
    },
    response: {
      headers: {
        'x-csrf-token': 'csrf-token', 
      },
      body: {
        // this is using brackets format {:users[:id]}
        // hello yosuke
        message: '{:greeting} {:users[:id]}',
      },
      values: {
        greeting: 'hello',
        users: [
            'furukawa',
            'haruka',
            'yosuke',
        ]
      }
    },
  }, 
]
```
