### PR TITLE
feat(client): support separate test running

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -24,7 +24,7 @@ class Client {
   }
 
   getAgreement() {
-    const agrees = requireUncached(this.agreesPath);
+    const agrees = [].concat(requireUncached(this.agreesPath));
     return this.completion(agrees);
   }
 

--- a/test/lib/client.js
+++ b/test/lib/client.js
@@ -33,3 +33,14 @@ test('feat(client): check request to server', () => {
     });
   });
 });
+
+
+test('feat(client): support single agree file', () => {
+  const client = new Client({
+    path: 'test/agrees/hoge/foo.json'
+  });
+
+  const agrees = client.getAgreement();
+  
+  assert(Array.isArray(agrees));
+});


### PR DESCRIPTION
```js
// agreed.js
module.exports = [
  './agreed/foo.js'
  './agreed/bar.js'
];
```
```
agreed-client --path agreed/foo.js --port 3030 --host example.com
```
