### PR TITLE
feat: Add nullish check in headers and url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
 script: npm test

--- a/lib/check/checker.js
+++ b/lib/check/checker.js
@@ -2,42 +2,156 @@
 
 const isInclude = require('./isInclude');
 const url = require("url");
+const logger = require("../utils/logger");
+
+const nullishStrings = ['undefined', 'null', ''];
 
 class Checker {
-  static request(request, req) {
+
+  static validRequest(result, request, req, debug) {
+    if (!result || !result.error) {
+      return true;
+    }
+
+    if (debug) {
+      logger.log(result.error);
+      logger.log('agreed request', request);
+      logger.log('actual request', req);
+    }
+
+    return false;
+  }
+
+  static request(request, req, options) {
     const parsedUrl = url.parse(req.url);
-    return Checker.method(request.method, req.method) &&
-      Checker.url(request.pathToRegexp, parsedUrl.pathname) &&
-      Checker.headers(request.headers, req.headers) &&
-      Checker.query(request.query, req.query) &&
-      Checker.body(request.body, req.body);
+    let similarity = 0;
+    let result = Checker.method(request.method, req.method);
+    similarity += result.similarity;
+    if (!Checker.validRequest(result, request, req, options.debug)) {
+      return { result: false, similarity, error: result.error };
+    }
+    result = Checker.url(request.pathToRegexp, parsedUrl.pathname, options);
+    similarity += result.similarity;
+    if (!Checker.validRequest(result, request, req, options.debug)) {
+      return { result: false, similarity, error: result.error };
+    }
+    result = Checker.headers(request.headers, req.headers, options);
+    similarity += result.similarity;
+    if (!Checker.validRequest(result, request, req, options.debug)) {
+      return { result: false, similarity, error: result.error };
+    }
+    result = Checker.query(request.query, req.query, options);
+    similarity += result.similarity;
+    if (!Checker.validRequest(result, request, req, options.debug)) {
+      return { result: false, similarity, error: result.error };
+    }
+    result = Checker.body(request.body, req.body, options);
+    similarity += result.similarity;
+    if (!Checker.validRequest(result, request, req, options.debug)) {
+      return { result: false, similarity, error: result.error };
+    }
+    return { result: true };
   }
 
   static method(entryMethod, reqMethod) {
-    return entryMethod.toLowerCase() === reqMethod.toLowerCase();
+    const result = { similarity: 1 };
+    if (entryMethod.toLowerCase() !== reqMethod.toLowerCase()) {
+      result.type = 'METHOD';
+      result.error = `Does not match METHOD, expect ${entryMethod}, but ${reqMethod}.`;
+      result.similarity = 0;
+    }
+    return result;
   }
 
-  static url(entryUrl, reqUrl) {
-    return entryUrl.exec(reqUrl) ? true : false;
+  static url(entryUrl, reqUrl, options) {
+    const result = { similarity: 1 };
+    const match = entryUrl.exec(reqUrl);
+    const { pathToRegexpKeys, values } = options;
+    if (!match) {
+      result.type = 'URL';
+      result.error = `Does not match URL, expect ${entryUrl}, but ${reqUrl}.`;
+      result.similarity = 0;
+      return result;
+    }
+    const paths = {};
+    pathToRegexpKeys.forEach((pathKey, index) => {
+      paths[pathKey.name] = match[index + 1];
+    });
+
+    const nullish = Checker.checkNullish(paths);
+    const nullishError = nullish.error;
+    const nullishSimilarity = nullish.similarity;
+    if (nullish) {
+      result.type = 'URL';
+      result.error = nullishError;
+      result.similarity = nullishSimilarity;
+      return result;
+    }
+
+    return result;
   }
 
-  static headers(entryHeaders, reqHeaders) {
-    if (!entryHeaders) return true;
-    return isInclude(entryHeaders, reqHeaders);
+  static headers(entryHeaders, reqHeaders, options) {
+    const result = { similarity: 1 };
+    if (!entryHeaders) return result;
+    if (!isInclude(entryHeaders, reqHeaders)) {
+      result.type = 'HEADERS';
+      result.error = `Does not include header, expect ${JSON.stringify(entryHeaders)} but ${JSON.stringify(reqHeaders)}`;
+      result.similarity = 0;
+    }
+
+    const nullish = Checker.checkNullish(reqHeaders);
+    const nullishError = nullish.error;
+    const nullishSimilarity = nullish.similarity;
+    if (nullish) {
+      result.type = 'HEADERS';
+      result.error = nullishError;
+      result.similarity = nullishSimilarity;
+      return result;
+    }
+    return result;
   }
 
-  static body(entryBody, reqBody) {
-    if (!entryBody) return true;
-    return isInclude(entryBody, reqBody);
+  static body(entryBody, reqBody, options) {
+    const result = { similarity: 1 };
+    if (!entryBody) return result;
+    if (!isInclude(entryBody, reqBody)) {
+      result.type = 'BODY';
+      result.error = `Does not include body, expect ${JSON.stringify(entryBody)} but ${JSON.stringify(reqBody)}`;
+      result.similarity = 0;
+    }
+    return result;
   }
 
-  static query(entryQuery, reqQuery) {
-    if (!entryQuery) return true;
-    return isInclude(entryQuery, reqQuery);
+  static query(entryQuery, reqQuery, options) {
+    const result = { similarity: 1 };
+    if (!entryQuery) return result;
+    if (!isInclude(entryQuery, reqQuery)) {
+      result.type = 'QUERY';
+      result.error = `Does not include query, expect ${JSON.stringify(entryQuery)} but ${JSON.stringify(reqQuery)}`;
+      result.similarity = 0;
+    }
+    return result;
   }
 
-  static status(entryStatus, resStatus) {
-    return entryStatus === resStatus;
+  static checkNullish(obj = {}) {
+    const result = { similarity: 1 };
+    const keys = Object.keys(obj);
+    for (var i=0; i<keys.length; i++) {
+      const key = keys[i];
+      const realValue = obj[key];
+
+      if (typeof realValue === 'object' && realValue) {
+        return Checker.checkNullish(realValue);
+      }
+
+      if (nullishStrings.indexOf(realValue) >= 0) {
+        result.error = `Request value has nullish strings ${realValue} in ${key}`;
+        result.similarity = 0.5;
+        return result;
+      }
+    }
+    return result;
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,12 +14,13 @@ const format = require('./template/format');
 const requireUncached = require('./require_hook/requireUncached');
 
 class Client {
-  constructor(options) {
+  constructor(options = {}) {
     this.agreesPath = path.resolve(options.path);
     this.base = path.dirname(this.agreesPath);
     this.scheme = options.scheme || 'http';
     this.host = options.host || 'localhost';
     this.port = options.port || 80;
+    this.options = options;
     register();
   }
 
@@ -57,7 +58,7 @@ class Client {
         const results = [];
         var finishCount = 0;
         responses.forEach((res, i) => {
-          const isSameStatus = Checker.status(agrees[i].response.status, res.statusCode);
+          const isSameStatus = agrees[i].response.status == res.statusCode;
           const checkStream = new CheckBodyStream();
           checkStream.expect(agrees[i].response.body);
           checkStream.schema(agrees[i].response.schema);

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,9 +13,10 @@ const bind = require('./template/bind');
 const requireUncached = require('./require_hook/requireUncached');
 
 class Server {
-  constructor(options) {
+  constructor(options = {}) {
     this.agreesPath = path.resolve(options.path);
     this.base = path.dirname(this.agreesPath);
+    this.options = options;
     register();
   }
 
@@ -23,14 +24,35 @@ class Server {
     const agrees = requireUncached(this.agreesPath).map((agree) => completion(agree, this.base));
 
     extract.incomingRequst(req).then((req) => {
-      const agree = agrees.find((agree) => Checker.request(agree.request, req));
+      const agreesWithResults = agrees.map((agree) => {
+        const { result, similarity, error } = Checker.request(agree.request, req, {
+          pathToRegexpKeys: agree.request.pathToRegexpKeys,
+          values: agree.request.values,
+          debug: this.options.debug,
+        });
+        return { agree, result, similarity, error };
+      });
 
-      if (!agree) {
+      const result = agreesWithResults.find(({ result }) => result);
+
+      if (!result || !result.agree) {
         res.statusCode = 404;
-        res.end('Agree Not Found');
+        const { agree, result, similarity, error } = 
+          agreesWithResults.sort((a, b) => b.similarity - a.similarity).shift();
+
+        if (similarity > 1) {
+          delete agree.request.pathToRegexp;
+          delete agree.request.pathToRegexpKeys;
+          res.end(`Agree Not Found, actual request is ${JSON.stringify(req)}, but similar agree request is ${JSON.stringify(agree.request)}, error: ${error}`);
+        } else {
+          res.end(`Agree Not Found`);
+        }
+
         typeof next === 'function' && next();
         return;
       }
+
+      const { agree } = result;
 
       // /foo/:id matched
       if (agree.request.pathToRegexpKeys.length > 0) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,0 +1,2 @@
+const logger = global.logger || console;
+module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "assert-stream": "^1.0.0",
     "body-parser": "^1.15.2",
     "codecov": "^1.0.1",
-    "eater": "^3.0.0-5",
+    "eater": "^3.2.0",
     "espower-loader": "^1.0.0",
     "express": "^4.14.0",
     "is-empty": "^1.0.0",

--- a/test/agrees/agrees.js
+++ b/test/agrees/agrees.js
@@ -284,4 +284,29 @@ module.exports = [
       }
     },
   },
+  {
+    request: {
+      path: '/headers/test/:index',
+      method: 'GET',
+      headers: {
+        'x-test-token': '{:xTestToken}'
+      },
+      values: {
+        index: 1,
+        xTestToken: 'fdajfdsaoijfdoajofdjaoj',
+      },
+    },
+    response: {
+      body: {
+        result : '{:list[:index]}'
+      },
+      values: {
+        list: [
+          'hello',
+          'hi',
+          'dunke',
+        ]
+      }
+    },
+  },
 ]

--- a/test/lib/check/checker.checkNullish.js
+++ b/test/lib/check/checker.checkNullish.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const test = require('eater/runner').test;
+const checker = require(`${process.cwd()}/lib/check/checker`);
+const assert = require('power-assert');
+
+test('checker[checkNullish]: check type { key: "foo" }, { key: "bar" } doest not have error ', () => {
+  const obj1 = {
+    key: "foo",
+  };
+
+  const obj2 = {
+    key: 'bar',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === undefined);
+});
+
+test('checker[checkNullish]: check type { key: "undefined" }, { key: "foo" } has error because undefined is nullish  ', () => {
+  const obj1 = {
+    key: "undefined",
+  };
+
+  const obj2 = {
+    key: 'foo',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === 'Request value has nullish strings undefined in key');
+});
+
+test('checker[checkNullish]: check type { key: "null" }, { key: "foo" } has error because null is nullish  ', () => {
+  const obj1 = {
+    key: "null",
+  };
+
+  const obj2 = {
+    key: 'foo',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === 'Request value has nullish strings null in key');
+});
+
+test('checker[checkNullish]: check type { key: "123" }, { key: 1 } does not have error', () => {
+  const obj1 = {
+    key: "123",
+  };
+
+  const obj2 = {
+    key: 1,
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === undefined);
+});
+
+test('checker[checkNullish]: check type { key: 1 }, { key: "3" } does not have error ', () => {
+  const obj1 = {
+    key: 1,
+  };
+
+  const obj2 = {
+    key: '3',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === undefined);
+});
+
+test('checker[checkNullish]: check nested type does not have error ', () => {
+  const obj1 = {
+    key: {
+      foo: 'test'
+    },
+  };
+
+  const obj2 = {
+    foo: 'hoge',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === undefined);
+});
+
+test('checker[checkNullish]: check nested type does not have error ', () => {
+  const obj1 = {
+    key: {
+      foo: {
+        bar: 'null'
+      }
+    },
+  };
+
+  const obj2 = {
+    bar: 'hoge',
+  };
+
+  assert(checker.checkNullish(obj1, obj2).error === 'Request value has nullish strings null in bar');
+});
+

--- a/test/lib/middleware.js
+++ b/test/lib/middleware.js
@@ -5,6 +5,7 @@ const Server = require(`${process.cwd()}/lib/server.js`);
 const AssertStream = require('assert-stream');
 const test = require('eater/runner').test;
 const http = require('http');
+const assert = require('power-assert');
 const plzPort = require('plz-port');
 
 test('feat(middleware): http GET API', () => {
@@ -56,6 +57,65 @@ test('feat(middleware): http PORT API', (done) => {
       });
 
       req.write(postData);
+      req.end();
+    });
+  });
+});
+
+test('error (middleware): http GET 404 API when nullish', (done) => {
+  plzPort().then((port) => {
+    const agreedServer = new Server({ path: 'test/agrees/agrees.js' });
+    const server = http.createServer((req, res) => {
+      agreedServer.useMiddleware(req, res);
+    }).listen(port);
+
+
+    server.on('listening', () => {
+      const options = {
+        host: 'localhost',
+        method: 'GET',
+        path: '/headers/null',
+        port: port,
+      };
+      const req = http.request(options, (res) => {
+        server.close();
+        assert(res.statusCode === 404);
+        let content = '';
+        res.on('data', (chunk) => content += chunk);
+        res.on('end', () => console.log(content));
+      });
+
+      req.end();
+    });
+  });
+});
+
+test('error (middleware): http GET 404 API when nullish headers', (done) => {
+  plzPort().then((port) => {
+    const agreedServer = new Server({ path: 'test/agrees/agrees.js' });
+    const server = http.createServer((req, res) => {
+      agreedServer.useMiddleware(req, res);
+    }).listen(port);
+
+
+    server.on('listening', () => {
+      const options = {
+        host: 'localhost',
+        method: 'GET',
+        path: '/headers/test/1',
+        headers: {
+          'x-test-token': 'null',
+        },
+        port: port,
+      };
+      const req = http.request(options, (res) => {
+        server.close();
+        assert(res.statusCode === 404);
+        let content = '';
+        res.on('data', (chunk) => content += chunk);
+        res.on('end', () => console.log(content));
+      });
+
       req.end();
     });
   });


### PR DESCRIPTION
Add nullish string check in headers and url.
If your agreed request has the following sample, 

```
  {
    request: {
      path: '/headers/:index',
      method: 'GET',
      values: {
        index: 1,
      },
    },
    response: {
      body: {
        result : '{:list[:index]}'
      },
      values: {
        list: [
          'hello',
          'hi',
          'dunke',
        ]
      }
    },
  },
```

but your request is `http://example.com/headers/null` or `http://example.com/headers/undefined` then throw errors like 'Request value has nullish strings null' .
