### PR TITLE
feat: Add defaultHeaders options for server middleware.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,7 @@ class Server {
     this.agreesPath = path.resolve(options.path);
     this.base = path.dirname(this.agreesPath);
     this.options = options;
+    this.defaultHeaders = options.defaultHeaders;
     register();
   }
 
@@ -78,9 +79,6 @@ class Server {
       }
 
       res.statusCode = agree.response.status;
-      Object.keys(agree.response.headers).forEach((header) => {
-        res.setHeader(header, agree.response.headers[header]);
-      });
 
       let messageBody = agree.response.body || '';
 
@@ -95,6 +93,14 @@ class Server {
       if (isContentJSON(agree.response)) {
         messageBody = JSON.stringify(messageBody);
       }
+
+      if (this.defaultHeaders && agree.response.headers) {
+        agree.response.headers = Object.assign(agree.response.headers, this.defaultHeaders);
+      }
+
+      Object.keys(agree.response.headers).forEach((header) => {
+        res.setHeader(header, format(agree.response.headers[header], Object.assign(agree.response.values || {}, agree.request.values || {})));
+      });
 
       res.end(messageBody);
     }).catch((e) => {

--- a/test/agrees/agrees.json5
+++ b/test/agrees/agrees.json5
@@ -69,4 +69,32 @@
       },
     },
   },
+  {
+    request: {
+      path: '/path/header/format',
+      method: 'GET',
+    },
+    response: {
+      headers: {
+        'access-control-allow-origin': '{:acao}'
+      },
+      body: {
+        message: 'hello',
+      },
+      values: {
+        'acao': '*'
+      }
+    },
+  },
+  {
+    request: {
+      path: '/path/default/header/',
+      method: 'GET',
+    },
+    response: {
+      body: {
+        message: 'hello',
+      },
+    },
+  },
 ]

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -6,6 +6,7 @@ const http = require('http');
 const AssertStream = require('assert-stream');
 const plzPort = require('plz-port');
 const assert = require('power-assert');
+const mustCall = require('must-call');
 
 test('server: POST API', () => {
   plzPort().then((port) => {
@@ -231,6 +232,57 @@ test('server: check response when header values are exists', () => {
         res.pipe(assertStream);
         server.close();
       }).on('error', console.error);
+      req.end();
+    });
+  });
+});
+
+test('server: response header has format string', () => {
+  plzPort().then((port) => {
+    const server = agreedServer({
+      path: 'test/agrees/agrees.json5',
+      port: port,
+    });
+
+    server.on('listening', () => {
+      const options = {
+        host: 'localhost',
+        method: 'GET',
+        path: '/path/header/format',
+        port: port,
+      };
+      const req = http.request(options, (res) => {
+        assert(res.statusCode === 200);
+        assert(res.headers['access-control-allow-origin'] === '*')
+        server.close();
+      }).on('error', console.error);
+      req.end();
+    });
+  });
+});
+
+test('server: response header using default headers', () => {
+  plzPort().then((port) => {
+    const server = agreedServer({
+      path: 'test/agrees/agrees.json5',
+      port: port,
+      defaultHeaders: {
+        'access-control-allow-origin': 'test'
+      }
+    });
+
+    server.on('listening', () => {
+      const options = {
+        host: 'localhost',
+        method: 'GET',
+        path: '/path/default/header/',
+        port: port,
+      };
+      const req = http.request(options, mustCall((res) => {
+        assert(res.statusCode === 200);
+        assert(res.headers['access-control-allow-origin'] === 'test')
+        server.close();
+      })).on('error', console.error);
       req.end();
     });
   });


### PR DESCRIPTION
Add default headers options.
This option can be used like the following example.

```js
    const server = agreedServer({
      path: 'test/agrees/agrees.json5',
      port: port,
      defaultHeaders: {
        'access-control-allow-origin': 'test'
      }
    });

```