### PR TITLE
fix: fix behavior when directory is given as path

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,7 +15,7 @@ const EventEmitter = require('events').EventEmitter;
 
 class Server {
   constructor(options = {}) {
-    this.agreesPath = path.resolve(options.path);
+    this.agreesPath = require.resolve(path.resolve(options.path));
     this.base = path.dirname(this.agreesPath);
     this.options = options;
     this.notifier = new EventEmitter();

--- a/test/agrees/index.js
+++ b/test/agrees/index.js
@@ -1,0 +1,4 @@
+module.exports = [
+  './hoge/foo.json',
+  './foo/bar.yaml'
+]

--- a/test/lib/server.path.js
+++ b/test/lib/server.path.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const agreedServer = require('../helper/server.js');
+const test = require('eater/runner').test;
+const http = require('http');
+const AssertStream = require('assert-stream');
+
+test('server: `path` option can be directory index', () => {
+  const server = agreedServer({
+    path: 'test/agrees',
+    port: 0,
+  });
+
+  server.on('listening', () => {
+    const postData = JSON.stringify({
+      message: 'foobarbaz',
+    }); 
+    const options = { 
+      host: 'localhost',
+      method: 'POST',
+      path: '/hoge/abc',
+      port: server.address().port,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(postData)
+      }   
+    };  
+    const req = http.request(options, (res) => {
+      const assert = new AssertStream();
+      assert.expect({"message":"hello post"});
+      res.pipe(assert);
+      server.close();
+    }).on('error', console.error);
+
+    req.write(postData);
+    req.end();
+  });
+});


### PR DESCRIPTION
When you have agree files like the below:
```
agreed/
├── api-1.js
├── api-2.js
└── index.js <- this is root agrees file
```
and you starts agreed-server like the below:

```
npx agreed-server --path agreed
```

Then `server.agreesPath` becomes `/path/to/pj-root/agreed` and `server.base` becomes `/path/to/pj-root`. In this case you need to reference `api-1.js` as `./agreed/api-1.js` in `agreed/index.js`.

However if you starts agreed-server like the below:

```
npx agreed-server --path agreed/index.js
```

Then `server.agreesPath` becomes `/path/to/pj-root/agreed/index.js` and `server.base` becomes `/path/to/pj-root/agreed` and you need to reference `api-1.js` as `./api-1.js` in `agreed/index.js`. This is inconsistent with the above.

This PR tries to fix this behavior. (Taking the first example as a bug and the second as correct behavior.)