### PR TITLE
feat(operation): add custom operation functions

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,15 +15,18 @@ const EventEmitter = require('events').EventEmitter;
 
 class Server {
   constructor(options = {}) {
-    this.agreesPath = require.resolve(path.resolve(options.path));
-    this.base = path.dirname(this.agreesPath);
+    this.agrees = options.agrees;
+    if (!options.agrees) {
+      this.agreesPath = require.resolve(path.resolve(options.path));
+      this.base = path.dirname(this.agreesPath);
+    }
     this.options = options;
     this.notifier = new EventEmitter();
     register();
   }
 
   useMiddleware(req, res, next) {
-    const agrees = requireUncached(this.agreesPath).map((agree) => completion(agree, this.base, this.options));
+    const agrees = (this.agrees || requireUncached(this.agreesPath)).map((agree) => completion(agree, this.base, this.options));
 
     extract.incomingRequst(req).then((req) => {
       const agreesWithResults = agrees.map((agree) => {
@@ -88,12 +91,12 @@ class Server {
       let messageBody = agree.response.body || '';
 
       if (agree.request.values) {
-        messageBody = format(messageBody, agree.request.values);
+        messageBody = format(messageBody, agree.request.values, agree.response.funcs);
       }
 
 
       if (agree.response.values) {
-        messageBody = format(messageBody, Object.assign({}, agree.response.values, agree.request.values));
+        messageBody = format(messageBody, Object.assign({}, agree.response.values, agree.request.values), agree.response.funcs);
       }
 
       if (isContentJSON(agree.response)) {
@@ -101,11 +104,11 @@ class Server {
       }
 
       Object.keys(agree.response.headers).forEach((header) => {
-        res.setHeader(header, format(agree.response.headers[header], Object.assign({}, agree.response.values || {}, agree.request.values || {})));
+        res.setHeader(header, format(agree.response.headers[header], Object.assign({}, agree.response.values || {}, agree.request.values || {}), agree.response.funcs));
       });
 
       if (agree.response.notify) {
-        const notify = format(agree.response.notify.body, Object.assign({}, agree.response.values || {}, agree.request.values || {}));
+        const notify = format(agree.response.notify.body, Object.assign({}, agree.response.values || {}, agree.request.values || {}), agree.response.funcs);
         this.notifier.emit(agree.response.notify.event || 'message', notify);
       }
 

--- a/lib/template/constants.js
+++ b/lib/template/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const OPERATIONAL_STRINGS = 'randomInt|parseInt|randomString|unixtime';
-const REGEXP_STRING = `{(${OPERATIONAL_STRINGS})*:([\\w|\\.|:|\\[|\\]|-]+)\\}`;
+const OPERATIONAL_STRINGS = '\\w+';
+const REGEXP_STRING = `{(${OPERATIONAL_STRINGS})*:([\\w|\\.|,|:|\\[|\\]|\\-]+)\\}`;
 const BRACKETS_STRING = '\\[:([\\w]+)\\]';
 const REST_ARRAY_STRING = '{:.+\\d+\-last}';
 

--- a/lib/template/format.js
+++ b/lib/template/format.js
@@ -5,15 +5,15 @@ module.exports = format;
 const constants = require('./constants');
 const operation = require('./operation');
 
-function format(template, args) {
+function format(template, args, funcs = {}) {
   var result = template;
 
   if (Array.isArray(template)) {
-    return formatArray(template, args);
+    return formatArray(template, args, funcs);
   }
 
   if (typeof template === 'object') {
-    return formatObject(template, args);
+    return formatObject(template, args, funcs);
   }
 
   if (typeof template !== 'string') {
@@ -45,38 +45,49 @@ function format(template, args) {
       });
     }
 
-    var value = rawKey.split('.').reduce((o, i) => {
-      if (o) {
-        const a = i.match(/(\d+)-(\d+|last)/);
-        if (a) {
-          const start = a[1];
-          const end = a[2] === 'last' ? o.length : a[2];
-          const array = o.slice(start, end);
-          array.__spread = true;
-          return array;
-        }
-        return o[i];
+    var value = rawKey.split(',').map((key) => {
+      if (key && args[key]) {
+        return args[key];
       }
-    }, args);
+      return key.split('.').reduce((val, k) => {
+        if (val) {
+          const a = k.match(/(\d+)-(\d+|last)/);
+          if (a) {
+            const start = a[1];
+            const end = a[2] === 'last' ? val.length : a[2];
+            const array = val.slice(start, end);
+            array.__spread = true;
+            return array;
+          }
+          return val[k];
+        }
+      }, args);
+    });
 
     var operationalKey = match.replace(constants.TEMPLATE_REGEXP, '$1');
+    if (operationalKey) {
+      value = operation(operationalKey, funcs, ...value);
+    }
 
-    if (value !== undefined) {
-      if (operationalKey) {
-        value = operation(operationalKey, value);
-      }
-      if (match === template) {
-        result = value;
-      } else {
-        result = result.replace(match, value);
-      }
+    if (Array.isArray(value)) {
+      value = value[0]
+    }
+
+    if (value === undefined) {
+      return
+    }
+
+    if (match === template) {
+      result = value;
+    } else {
+      result = result.replace(match, value);
     }
   });
 
   return result;
 }
 
-function formatObject(obj, args) {
+function formatObject(obj, args, funcs) {
   var result = {};
   if (!obj) {
     return obj;
@@ -84,19 +95,19 @@ function formatObject(obj, args) {
 
   Object.keys(obj).forEach((key) => {
     const value = obj[key];
-    result[key] = format(value, args);
+    result[key] = format(value, args, funcs);
   });
   return result;
 }
 
-function formatArray(array, args) {
+function formatArray(array, args, funcs) {
   var result = [];
   if (!array) {
     return array;
   }
 
   array.forEach((item) => {
-    const formattedItem = format(item, args);
+    const formattedItem = format(item, args, funcs);
     if (formattedItem.__spread) {
       formattedItem.forEach((item) => {
         result.push(item);

--- a/lib/template/operation/index.js
+++ b/lib/template/operation/index.js
@@ -4,10 +4,18 @@ const randomInt = require('./randomInt');
 const randomString = require('./randomString');
 const parseInt = require('./parseInt');
 const unixtime = require('./unixtime');
+const path = require('path');
 
-
-module.exports = (operation, ...values) => {
-  if (operation === 'randomInt') {
+module.exports = (operation, funcs, ...values) => {
+  if (typeof funcs[operation] === 'function') {
+    const result = funcs[operation](...values);
+    return result;
+  } else if (typeof funcs[operation] === 'string') {
+    const basedir = funcs.basedir || process.cwd();
+    const funcPath = path.resolve(basedir, funcs[operation]);
+    const result = require(funcPath)(...values)
+    return result;
+  } else if (operation === 'randomInt') {
     const [ value ] = values;
     const result = randomInt(value);
     return result;

--- a/test/agrees/sub.js
+++ b/test/agrees/sub.js
@@ -1,0 +1,1 @@
+module.exports = (a, b) => a - b 

--- a/test/lib/server.customFuncs.js
+++ b/test/lib/server.customFuncs.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const agreedServer = require('../helper/server.js');
+const test = require('eater/runner').test;
+const http = require('http');
+const AssertStream = require('assert-stream');
+const assert = require('power-assert');
+const mustCall = require('must-call');
+
+test('server: check custom function', () => {
+  const server = agreedServer({
+    agrees: [{
+      request: {
+        path: '/test/custom/agreed/values',
+        query: {
+          a: '{:a}',
+          b: '{:b}',
+          c: '{:c}',
+        },
+        values: {
+          a: 1,
+          b: 2,
+          c: 3,
+        },
+      },
+      response: {
+        body: {
+          sum: '{sum:a,b,c}',
+        },
+        funcs: {
+          sum: (a, b, c) => parseInt(a) + parseInt(b) + parseInt(c)
+        }
+      },
+    }],
+    port: 0,
+  });
+
+  server.on('listening', () => {
+    const options = {
+      host: 'localhost',
+      method: 'GET',
+      path: '/test/custom/agreed/values?a=1&b=2&c=4',
+      port: server.address().port,
+    };
+    const req = http.request(options, (res) => {
+      let data = '';
+      res.on('data', (d) => data += d);
+      res.on('end', mustCall(() => {
+        const result = JSON.parse(data);
+        assert.strictEqual(result.sum, 7);
+      }));
+      server.close();
+    }).on('error', console.error);
+
+    req.end();
+  });
+});
+

--- a/test/lib/template/format.js
+++ b/test/lib/template/format.js
@@ -220,8 +220,6 @@ test('format: array 1-last notation to spread array', () => {
     ]
   });
 
-
-  console.log(result);
   assert.deepStrictEqual(result, {
     arr: [
       {
@@ -313,8 +311,6 @@ test('format: array 1-last notation to spread array with null', () => {
     ]
   });
 
-
-  console.log(result);
   assert.deepStrictEqual(result, {
     arr: [
       {

--- a/test/lib/template/format.operationalKey.js
+++ b/test/lib/template/format.operationalKey.js
@@ -29,7 +29,18 @@ test('format: {parseInt:id}', () => {
 });
 
 test('format: {unixtime:time}', () => {
-  const unixtime = parseInt(Date.now() / 1000)
+  const unixtime = parseInt(Date.now() / 1000);
   const result = format({ time: '{unixtime:time}' }, { time: '10000' });
   assert(result.time >= unixtime);
+});
+
+test('format: {sum:a,b}', () => {
+  const sum = (a, b) => a + b;
+  const result = format({ sum: '{sum:a,b}' }, { a: 1, b: 2 }, { sum: sum });
+  assert.strictEqual(result.sum, 3);
+});
+
+test('format: {sub:a,b}', () => {
+  const result = format({ sub: '{sub:a,b}' }, { a: 1, b: 2 }, { sub: './test/agrees/sub.js', basedir: process.cwd() });
+  assert.strictEqual(result.sub, -1);
 });


### PR DESCRIPTION
Add custom operation functions.
Usage:

```javascript
{
      request: {
        path: '/test/custom/agreed/values',
        query: {
          a: '{:a}',
          b: '{:b}',
          c: '{:c}',
        },
        values: {
          a: 1,
          b: 2,
          c: 3,
        },
      },
      response: {
        body: {
          sum: '{sum:a,b,c}',
        },
        funcs: {
          sum: (a, b, c) => parseInt(a) + parseInt(b) + parseInt(c)
        }
      },
    }
```

